### PR TITLE
Add extention to BloodImage_00171.jpg

### DIFF
--- a/BCCD/Annotations/BloodImage_00171.xml
+++ b/BCCD/Annotations/BloodImage_00171.xml
@@ -1,6 +1,6 @@
 <annotation verified="no">
   <folder>RBC</folder>
-  <filename>BloodImage_00171</filename>
+  <filename>BloodImage_00171.jpg</filename>
   <path>/Users/cosmic/WBC_CLASSIFICATION_ANNO/RBC/BloodImage_00171.jpg</path>
   <source>
     <database>Unknown</database>


### PR DESCRIPTION
When I tried use this repository with an FRCNN, I noticed that was one Annotation <filename> content that din't have the extension of the file image like all others <filename>  contents in annotations files.

To fix this in my code, i will need add an condition to validate ALL files verifying if it have an extension, to don't need to this, i resolve fix it in the dataset.

<filename>BloodImage_00171.jpg</filename>